### PR TITLE
Fix missing vmalloc headers and kernel module Makefile

### DIFF
--- a/sw/AMI/driver/Makefile
+++ b/sw/AMI/driver/Makefile
@@ -25,20 +25,16 @@ $(TARGET_MODULE)-objs += gcq-driver/src/gcq_driver.o
 $(TARGET_MODULE)-objs += gcq-driver/src/gcq_hw.o
 $(TARGET_MODULE)-objs += gcq-driver/src/gcq_features.o
 
-EXTRA_CFLAGS:=-I$(PWD) -I$(PWD)/fal -I$(PWD)/fal/gcq -I$(PWD)/gcq-driver/src
+# To apply the macro to all the source files compiled with this makefile
+ccflags-y := -I$(src) -I$(src)/fal -I$(src)/fal/gcq -I$(src)/gcq-driver/src
+ccflags-y += -DDEBUG -DVERBOSE_DEBUG -DGCQ_MAX_INSTANCES=16
 
-KERNEL_DIR = /lib/modules/`uname -r`/build
-
-#CFLAGS_file_name will apply the macros to those files
-# CFLAGS_versal_vmc.o:=-DDEBUG
-
-#To apply the macro to all the source files compiled with this makefile
-# ccflags-y:=-DDEBUG
-ccflags-y:=-DDEBUG -DVERBOSE_DEBUG -DGCQ_MAX_INSTANCES=16
+KERNEL_DIR ?= /lib/modules/$(shell uname -r)/build
+PWD := $(shell pwd)
 
 all: clean
 	@test -f ../scripts/getVersion.sh && ../scripts/getVersion.sh driver $(realpath .) || echo ""
-	$(MAKE) -C ${KERNEL_DIR} M=${PWD} modules
+	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) modules
 
 clean:
-	$(MAKE) -C ${KERNEL_DIR} M=${PWD} clean
+	$(MAKE) -C $(KERNEL_DIR) M=$(PWD) clean

--- a/sw/AMI/driver/ami_amc_control.c
+++ b/sw/AMI/driver/ami_amc_control.c
@@ -9,6 +9,7 @@
 #include <linux/delay.h>
 #include <linux/device.h>
 #include <linux/types.h>
+#include <linux/vmalloc.h>
 
 #include "gcq.h"
 #include "ami_top.h"

--- a/sw/AMI/driver/ami_cdev.c
+++ b/sw/AMI/driver/ami_cdev.c
@@ -15,6 +15,7 @@
 #include <linux/hwmon.h>
 #include <linux/eventfd.h>
 #include <linux/version.h>
+#include <linux/vmalloc.h>
 
 #include "ami.h"
 #include "ami_hwmon.h"

--- a/sw/AMI/driver/ami_sensor.c
+++ b/sw/AMI/driver/ami_sensor.c
@@ -8,6 +8,7 @@
 #include <linux/kthread.h>
 #include <linux/delay.h>
 #include <linux/jiffies.h>
+#include <linux/vmalloc.h>
 
 #include "ami_top.h"
 #include "ami_sensor.h"

--- a/sw/AMI/driver/ami_sysfs.c
+++ b/sw/AMI/driver/ami_sysfs.c
@@ -7,6 +7,7 @@
 
 #include <linux/device.h>
 #include <linux/kernel.h>
+#include <linux/vmalloc.h>
 
 #include "ami.h"
 #include "ami_top.h"


### PR DESCRIPTION
This PR addresses compilation warnings for the AMI driver. It fixes missing header dependencies and updates the Makefile to follow current Kbuild conventions.