### PR TITLE
ci: add SCANOSS license compliance scanning

### DIFF
--- a/.github/workflows/scanoss.yml
+++ b/.github/workflows/scanoss.yml
@@ -1,0 +1,128 @@
+name: SCANOSS License Compliance
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
+concurrency:
+  group: scanoss-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scanoss-pr:
+    name: SCANOSS License Scan (PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: SCANOSS Delta Scan
+        uses: scanoss/gha-code-scan@v1
+        with:
+          api.key: ${{ secrets.SCANOSS_API_KEY }}
+          github.token: ${{ steps.app-token.outputs.token }}
+          policies: copyleft
+          policies.halt_on_failure: false
+          scanMode: delta
+          dependencies.enabled: false
+          output.filepath: scanoss-results.json
+
+  scanoss-full:
+    name: SCANOSS Full Scan (post-merge)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Remove non-source files that crash SCANOSS
+        run: |
+          find . -type f \( \
+            -name '*.pcap' -o -name '*.pcapng' -o -name '*.tsv' -o -name '*.csv' \
+            -o -name '*.bin' -o -name '*.png' -o -name '*.jpg' -o -name '*.jpeg' \
+            -o -name '*.gif' -o -name '*.webp' -o -name '*.avif' -o -name '*.svg' \
+            -o -name '*.ico' -o -name '*.pdf' \
+            -o -name '*.mp3' -o -name '*.mp4' -o -name '*.mov' -o -name '*.wav' \
+            -o -name '*.woff' -o -name '*.woff2' -o -name '*.ttf' -o -name '*.otf' \
+            -o -name '*.eot' \
+            -o -name '*.gz' -o -name '*.tar' -o -name '*.zip' -o -name '*.whl' \
+            -o -name '*.7z' -o -name '*.rar' \
+            -o -name '*.o' -o -name '*.a' -o -name '*.so' -o -name '*.dylib' \
+            -o -name '*.dll' -o -name '*.exe' -o -name '*.class' -o -name '*.jar' \
+            -o -name '*.pyc' -o -name '*.pdi' -o -name '*.xsa' -o -name '*.elf' \
+            -o -name '*.hpu' -o -name '*.bcode' -o -name '*.cbor' \
+          \) -delete 2>/dev/null || true
+          rm -rf Datasets assets node_modules __pycache__ .venv bmenv .next dist build 2>/dev/null || true
+
+      - name: SCANOSS Full Scan
+        uses: scanoss/gha-code-scan@v1
+        with:
+          api.key: ${{ secrets.SCANOSS_API_KEY }}
+          github.token: ${{ steps.app-token.outputs.token }}
+          policies: copyleft
+          policies.halt_on_failure: false
+          scanMode: full
+          dependencies.enabled: false
+          output.filepath: scanoss-results.json
+
+  trigger-ort:
+    name: Trigger ORT Scan
+    if: github.event_name == 'push'
+    runs-on: self-hosted
+    steps:
+      - name: Check if ORT scan needed
+        id: check
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Skip if only NOTICE changed
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "FORCE_SCAN")
+          if [ "$(echo "$CHANGED" | grep -v '^NOTICE$' | grep -v '^$')" = "" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger ORT scan via webhook
+        if: steps.filter.outputs.skip != 'true'
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          HTTP_CODE=$(curl -s -o /tmp/ort-response.json -w "%{http_code}" -X POST "${{ vars.ORT_WEBHOOK_URL }}/scan" -H "Authorization: Bearer ${{ secrets.ORT_WEBHOOK_TOKEN }}" -H "Content-Type: application/json" -d "{\"repo\": \"${REPO_NAME}\"}")
+          echo "HTTP $HTTP_CODE"
+          cat /tmp/ort-response.json
+          if [ "$HTTP_CODE" = "202" ]; then
+            echo "::notice::ORT scan triggered for $REPO_NAME"
+          else
+            echo "::warning::ORT webhook returned $HTTP_CODE — scan may not have started"
+          fi

--- a/NOTICE
+++ b/NOTICE
@@ -14,10 +14,8 @@ notices as required by those licenses.
 
 LICENSE SUMMARY
 
-  CC0-1.0: 1 component(s)
-  GPL-2.0-only [COPYLEFT]: 1 component(s)
+  GPL-2.0-only [COPYLEFT]: 2 component(s)
   MIT: 2 component(s)
-  Unlicense: 1 component(s)
   X11: 1 component(s)
 
 ------------------------------------------------------------
@@ -63,7 +61,7 @@ COMPONENT ATTRIBUTIONS
   PURL: pkg:github/owntracks/recorder
   Copyright:
     Copyright (C) 2011 Joseph A. Adams (joeyadams3.14159@gmail.com)
-  License: CC0-1.0, Unlicense
+  License: GPL-2.0-only
 
 ------------------------------------------------------------
 
@@ -92,20 +90,38 @@ SOFTWARE.
 
 --- GPL-2.0-only ---
 
-Full license text available at: https://spdx.org/licenses/GPL-2.0-only.html
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation; version 2 of the License.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Full license text: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
 
 --- X11 ---
 
-Full license text available at: https://spdx.org/licenses/X11.html
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
---- CC0-1.0 ---
-
-Full license text available at: https://spdx.org/licenses/CC0-1.0.html
-
-
---- Unlicense ---
-
-Full license text available at: https://spdx.org/licenses/Unlicense.html
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,111 @@
+THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
+============================================================
+
+Project: AVED-fork
+Generated: 2026-04-24
+Tool: SCANOSS (snippet detection with License dataset)
+Components: 3
+
+This file lists all third-party software components detected
+in this repository, along with their licenses and copyright
+notices as required by those licenses.
+
+------------------------------------------------------------
+
+LICENSE SUMMARY
+
+  CC0-1.0: 1 component(s)
+  GPL-2.0-only [COPYLEFT]: 1 component(s)
+  MIT: 2 component(s)
+  Unlicense: 1 component(s)
+  X11: 1 component(s)
+
+------------------------------------------------------------
+
+COMPONENT ATTRIBUTIONS
+
+  aved
+  Version: amd_v80_gen5x8_23.2_exdes_1_20231204
+  Source: https://github.com/xilinx/aved
+  PURL: pkg:github/xilinx/aved
+  Copyright:
+    (c) Copyright 2022; Advanced Micro Devices; Inc.
+    (c) Copyright 2023; Advanced Micro Devices; Inc.
+    (c) Copyright 2024; Advanced Micro Devices; Inc.
+    Copyright 2023-2025 Advanced Micro Devices Inc. All rights reserved
+    Copyright (C) 2023 Advanced Micro Devices; Inc. All rights reserved.
+    Copyright (C) 2023; Advanced Micro Devices; Inc. All rights reserved.
+    Copyright (C) 2023; Advanced Micro Devices; Inc. All rights reserved.        #
+    Copyright (c) 2023 Advanced Micro Devices; Inc.
+    Copyright (c) 2023 Advanced Micro Devices; Inc. All rights reserved.
+    Copyright (c) 2023-present Advanced Micro Devices; Inc.
+    Copyright (c) 2023-present Advanced Micro Devices; Inc. All rights reserved.
+    Copyright (c) 2023; Advanced Micro Devices; Inc.
+    Copyright (c) 2024 Advanced Micro Devices; Inc.
+    Copyright (c) 2024 Advanced Micro Devices; Inc. All rights reserved.
+    Copyright 2022; Advanced Micro Devices; Inc.
+    Copyright 2023; Advanced Micro Devices; Inc.
+    Copyright 2024; Advanced Micro Devices; Inc.
+  License: GPL-2.0-only, MIT, X11
+
+  gemtools
+  Version: v1.7
+  Source: https://github.com/gemtools/gemtools
+  PURL: pkg:github/gemtools/gemtools
+  Copyright:
+    Copyright (C) 2011 Joseph A. Adams (joeyadams3.14159@gmail.com)
+    Copyright (c) 2011 Joseph A. Adams (joeyadams3.14159@gmail.com)
+  License: MIT
+
+  recorder
+  Version: 0.2.2
+  Source: https://github.com/owntracks/recorder
+  PURL: pkg:github/owntracks/recorder
+  Copyright:
+    Copyright (C) 2011 Joseph A. Adams (joeyadams3.14159@gmail.com)
+  License: CC0-1.0, Unlicense
+
+------------------------------------------------------------
+
+FULL LICENSE TEXTS
+
+--- MIT ---
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+--- GPL-2.0-only ---
+
+Full license text available at: https://spdx.org/licenses/GPL-2.0-only.html
+
+
+--- X11 ---
+
+Full license text available at: https://spdx.org/licenses/X11.html
+
+
+--- CC0-1.0 ---
+
+Full license text available at: https://spdx.org/licenses/CC0-1.0.html
+
+
+--- Unlicense ---
+
+Full license text available at: https://spdx.org/licenses/Unlicense.html
+

--- a/scanoss.json
+++ b/scanoss.json
@@ -1,0 +1,7 @@
+{
+  "bom": {
+    "include": [
+      {"purl":"pkg:github/Xilinx/AVED","comment":"Known GPL upstream - AMD AVED"}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add SCANOSS GitHub Action for automated license compliance scanning
- Scans PRs (delta) and pushes to main (full) for copyleft license violations
- Posts findings as PR comments — does NOT block merges
- Add `scanoss.json` configuration for component declarations

Part of org-wide compliance initiative.

## Test plan
- [ ] Verify SCANOSS action runs on next PR
- [ ] Verify no false positives on existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)