### PR TITLE
ami: fix eventfd_signal() build on RHEL 9.5+

### DIFF
--- a/sw/AMI/driver/ami_program.c
+++ b/sw/AMI/driver/ami_program.c
@@ -91,7 +91,8 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 				break;
 
 			if (efd_ctx) {
-				#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+				#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || \
+					(defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))
 					eventfd_signal(efd_ctx);
 				#else
 					eventfd_signal(efd_ctx, bytes_to_write);
@@ -150,7 +151,8 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 			buf, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
 
 		if (!ret && efd_ctx)
-		#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
+		#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || \
+			(defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))
 			eventfd_signal(efd_ctx);
 		#else
 			eventfd_signal(efd_ctx, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));

--- a/sw/AMI/driver/ami_program.c
+++ b/sw/AMI/driver/ami_program.c
@@ -91,11 +91,18 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 				break;
 
 			if (efd_ctx) {
-				#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || \
-					(defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))
+				#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
 					eventfd_signal(efd_ctx);
 				#else
+				# ifdef RHEL_RELEASE_CODE
+				#  if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)
+					eventfd_signal(efd_ctx);
+				#  else
 					eventfd_signal(efd_ctx, bytes_to_write);
+				#  endif
+				# else
+					eventfd_signal(efd_ctx, bytes_to_write);
+				# endif
 				#endif
 			}
 		} else {
@@ -151,11 +158,18 @@ static int do_image_download(struct amc_control_ctxt *amc_ctrl_ctxt, uint8_t *bu
 			buf, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
 
 		if (!ret && efd_ctx)
-		#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || \
-			(defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))
+		#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
 			eventfd_signal(efd_ctx);
 		#else
+		# ifdef RHEL_RELEASE_CODE
+		#  if RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)
+			eventfd_signal(efd_ctx);
+		#  else
 			eventfd_signal(efd_ctx, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
+		#  endif
+		# else
+			eventfd_signal(efd_ctx, (PDI_CHUNK_SIZE * PDI_CHUNK_MULTIPLIER));
+		# endif
 		#endif
 	}
 


### PR DESCRIPTION
Fixes #33

Extend the `eventfd_signal()` preprocessor gate in `sw/AMI/driver/ami_program.c` so that the new one-argument form is also selected on RHEL 9.5+ and its rebuilds (Rocky Linux 9.5+, AlmaLinux 9.5+, …), where Red Hat backported the upstream v6.8 `eventfd_signal()` simplification into the 5.14-based kernel. See the linked issue for the full root-cause and reproduction.

Before:

```c
#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
    eventfd_signal(efd_ctx);
#else
    eventfd_signal(efd_ctx, bytes_to_write);
#endif
```

After:

```c
#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || \
    (defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))
    eventfd_signal(efd_ctx);
#else
    eventfd_signal(efd_ctx, bytes_to_write);
#endif
```

The same change is applied to the second `eventfd_signal()` call site (the boot-tag rewrite path), so the two gates stay in sync.

The form chosen here, `defined(RHEL_RELEASE_CODE) && RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)`, is the same idiom already used by this driver in `sw/AMI/driver/ami_cdev.c` for the `class_create()` / `devnode()` signature change, so it's consistent with existing AVED conventions. 


## Downstream context

We are currently carrying this fix downstream in SLASH (https://github.com/Xilinx/SLASH) as a `sed` patch applied in `scripts/package-ami.sh` right before `gen_package.py` is invoked, and reverted on exit:

```bash
# Extend the eventfd_signal() version gate in ami_program.c so the
# void-arg form is also picked up on RHEL 9.5+, which is when Red Hat
# backported the upstream 6.8 eventfd_signal() simplification into the
# 5.14-based kernel.
sed -i 's@#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)$@#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0) || (defined(RHEL_RELEASE_CODE) \&\& RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5))@' "${AMI_PROGRAM_C}"
```

The `sed` produces exactly the diff in this PR, and we have verified it works: with the patch applied, `gen_package.py` produces a working `ami-*.rpm` whose `ami.ko` builds with DKMS and loads cleanly on Rocky Linux 9.6 (`kernel-5.14.0-570.58.1.el9_6.x86_64`). Without it, packaging breaks at compile time on the same machine.



## Testing

- Rocky Linux 9.6, `kernel-5.14.0-570.58.1.el9_6.x86_64` — **fails** without this PR, **builds + loads** with it; PDI download via
  `ami_tool` works end-to-end and the eventfd progress notifications fire.
- Ubuntu 24.04 (kernel 6.8) — unchanged, still picks the one-arg branch via the `LINUX_VERSION_CODE` term.