### PR TITLE
Fix driver build failures by correcting Kbuild flags and missing vmalloc header

### DIFF
--- a/sw/AMI/driver/Makefile
+++ b/sw/AMI/driver/Makefile
@@ -25,7 +25,7 @@ $(TARGET_MODULE)-objs += gcq-driver/src/gcq_driver.o
 $(TARGET_MODULE)-objs += gcq-driver/src/gcq_hw.o
 $(TARGET_MODULE)-objs += gcq-driver/src/gcq_features.o
 
-EXTRA_CFLAGS:=-I$(PWD) -I$(PWD)/fal -I$(PWD)/fal/gcq -I$(PWD)/gcq-driver/src
+ccflags-y := -I$(PWD) -I$(PWD)/fal -I$(PWD)/fal/gcq -I$(PWD)/gcq-driver/src
 
 KERNEL_DIR = /lib/modules/`uname -r`/build
 
@@ -33,8 +33,8 @@ KERNEL_DIR = /lib/modules/`uname -r`/build
 # CFLAGS_versal_vmc.o:=-DDEBUG
 
 #To apply the macro to all the source files compiled with this makefile
-# ccflags-y:=-DDEBUG
-ccflags-y:=-DDEBUG -DVERBOSE_DEBUG -DGCQ_MAX_INSTANCES=16
+ccflags-y += -DDEBUG
+ccflags-y += -DVERBOSE_DEBUG -DGCQ_MAX_INSTANCES=16
 
 all: clean
 	@test -f ../scripts/getVersion.sh && ../scripts/getVersion.sh driver $(realpath .) || echo ""

--- a/sw/AMI/driver/ami_amc_control.c
+++ b/sw/AMI/driver/ami_amc_control.c
@@ -9,6 +9,7 @@
 #include <linux/delay.h>
 #include <linux/device.h>
 #include <linux/types.h>
+#include <linux/vmalloc.h>
 
 #include "gcq.h"
 #include "ami_top.h"

--- a/sw/AMI/driver/ami_cdev.c
+++ b/sw/AMI/driver/ami_cdev.c
@@ -15,6 +15,7 @@
 #include <linux/hwmon.h>
 #include <linux/eventfd.h>
 #include <linux/version.h>
+#include <linux/vmalloc.h>
 
 #include "ami.h"
 #include "ami_hwmon.h"

--- a/sw/AMI/driver/ami_sensor.c
+++ b/sw/AMI/driver/ami_sensor.c
@@ -8,6 +8,7 @@
 #include <linux/kthread.h>
 #include <linux/delay.h>
 #include <linux/jiffies.h>
+#include <linux/vmalloc.h>
 
 #include "ami_top.h"
 #include "ami_sensor.h"

--- a/sw/AMI/driver/ami_sysfs.c
+++ b/sw/AMI/driver/ami_sysfs.c
@@ -7,6 +7,7 @@
 
 #include <linux/device.h>
 #include <linux/kernel.h>
+#include <linux/vmalloc.h>
 
 #include "ami.h"
 #include "ami_top.h"


### PR DESCRIPTION
## Description

This PR addresses two critical compilation issues that were preventing the AMI driver from building successfully on newer kernel versions:

1. **Inactive Compilation Flags (`EXTRA_CFLAGS`)**:
Modern Kbuild environments deprecate or ignore local `EXTRA_CFLAGS` variable assignments when executing sub-makes, causing the `-I` include paths for local dependencies to be lost. This has been fixed by properly appending the include paths to `ccflags-y`.
2. **Implicit Function Declarations (`vzalloc`/`vfree`)**:
The driver utilizes memory allocation functions like `vzalloc()` and `vfree()` across multiple files without explicitly importing their definitions. This caused build failures on newer, stricter kernel headers. Explicit `#include <linux/vmalloc.h>` directives have been added to the affected source files.



## Changes

* **`Makefile`**: Appended header include paths directly to `ccflags-y` instead of the defunct `EXTRA_CFLAGS`.
* **`sw/AMI/driver/ami_amc_control.c`**: Added `<linux/vmalloc.h>` inclusion.
* **`sw/AMI/driver/ami_cdev.c`**: Added `<linux/vmalloc.h>` inclusion.
* **`sw/AMI/driver/ami_sensor.c`**: Added `<linux/vmalloc.h>` inclusion.
* **`sw/AMI/driver/ami_sysfs.c`**: Added `<linux/vmalloc.h>` inclusion.


Fix: https://github.com/Xilinx/AVED/issues/35