### PR TITLE
Fix incorrect parameter usage in find_pci_ext_capability function

### DIFF
--- a/sw/AMI/driver/ami_pci_dbg.c
+++ b/sw/AMI/driver/ami_pci_dbg.c
@@ -894,8 +894,8 @@ void find_pci_ext_capability(struct pci_dev *dev, char *cap_name, int cap)
 
 	if (!dev || !cap_name)
 		return;
-	
-	ret = pci_find_ext_capability(dev, PCI_CAP_ID_PM);
+
+	ret = pci_find_ext_capability(dev, cap);
 	if (ret == CAP_NOT_FOUND)
 		DEV_VDBG(dev, "PCIe extended capability not found: %s", cap_name);
 	else


### PR DESCRIPTION
Fix #37 

Before applying the patch:

<details>

```
$ journalctl -b -2 | grep -E "ami.*PCIe extended capability"
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_ERR
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_VC
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_DSN
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_PWR
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_RCLD
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_RCILC
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_RCEC
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_MFVC
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_VC9
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_RCRB
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_VNDR
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_CAC
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_ACS
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_ARI
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_ATS
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_SRIOV
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_MRIOV
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_MCAST
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_PRI
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_AMD_XXX
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_REBAR
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_DPA
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_TPH
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_LTR
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_SECPCI
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_PMUX
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_PASID
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_DPC
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_L1SS
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_PTM
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_DLF
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_PL_16GT
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_LANE_MERGE_REC
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_HIERARCHY_ID
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_NPEM
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_PHY_LAYER_32_GTS
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_ALT_PROTOCOL
Jun 03 13:56:15 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_SFI
```

</details>

After applying the patch:


<details>

```
$ journalctl -b | grep -E "ami.*PCIe extended capability"
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_ERR
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_VC
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_DSN
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_PWR
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_RCLD
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_RCILC
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_RCEC
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_MFVC
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_VC9
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_RCRB
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_VNDR
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_CAC
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_ACS
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_ARI
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_ATS
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_SRIOV
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_MRIOV
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_MCAST
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_PRI
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_AMD_XXX
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_REBAR
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_DPA
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_TPH
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_LTR
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_SECPCI
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_PMUX
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_PASID
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_DPC
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_L1SS
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_PTM
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_DLF
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_PL_16GT
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_LANE_MERGE_REC
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_HIERARCHY_ID
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_NPEM
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : Found PCIe extended capability: PCI_EXT_CAP_ID_PHY_LAYER_32_GTS
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_ID_ALT_PROTOCOL
Jun 03 15:44:25 hostname kernel: ami 0000:41:00.0: VERBOSE DEBUG           : PCIe extended capability not found: PCI_EXT_CAP_SFI
```

</details>
